### PR TITLE
Reduced memory requirement for filterPeaks

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^CRAN-RELEASE$
 ^cran-comments.md$
 ^\.github$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.o
 *.rds
 CRAN-RELEASE
+.Rproj.user

--- a/MALDIquant.Rproj
+++ b/MALDIquant.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/as.matrix-functions.R
+++ b/R/as.matrix-functions.R
@@ -63,4 +63,5 @@
   i <- findInterval(mass, uniqueMass)
   
   return(list(r = as.integer(r), i = as.integer(i), masses = uniqueMass))
+  
 }

--- a/R/as.matrix-functions.R
+++ b/R/as.matrix-functions.R
@@ -25,6 +25,7 @@
   m
 }
 
+
 ## .as.binary.matrix
 ##  internal function to convert a matrix with NA to a binary one
 ##
@@ -40,4 +41,26 @@
   m[isNA] <- 0L
   mode(m) <- "integer"
   m
+}
+
+## .as.occurrence.list
+##  internal function to create a list of peaks occurrence
+##
+## params:
+##  l: list of AbstractMassObject objects
+##
+## returns:
+##  a list
+.as.occurrence.list <- function(l) {
+  
+  .stopIfNotIsMassObjectList(l)
+  
+  mass <- .unlist(lapply(l, function(x)x@mass))
+  uniqueMass <- sort.int(unique(mass))
+  n <- lengths(l)
+  r <- rep.int(seq_along(l), n)
+  
+  i <- findInterval(mass, uniqueMass)
+  
+  return(list(r = as.integer(r), i = as.integer(i), masses = uniqueMass))
 }


### PR DESCRIPTION
Hi,
I've modified the `filterPeaks` function to use less memory. The current implementation uses a binary matrix for the peaks occurrence. I've defined a list with row, columns only, which should require less memory, if the occurrence is sparse. I've passed the tests on MacOS.